### PR TITLE
Update install script to v4

### DIFF
--- a/src/commands/autoinstrument.yml
+++ b/src/commands/autoinstrument.yml
@@ -43,7 +43,7 @@ steps:
         DD_SET_TRACER_VERSION_JS: <<parameters.js_tracer_version>>
         DD_SET_TRACER_VERSION_PYTHON: <<parameters.python_tracer_version>>
         DD_INSTRUMENTATION_BUILD_SYSTEM_JAVA: <<parameters.java_instrumented_build_system>>
-        INSTALLATION_SCRIPT_URL: https://install.datadoghq.com/scripts/install_test_visibility_v3.sh
-        INSTALLATION_SCRIPT_CHECKSUM: 14f41bd44247591c442aab691902d8172765548fe71b32aa579d969c5fe43c54
+        INSTALLATION_SCRIPT_URL: https://install.datadoghq.com/scripts/install_test_visibility_v4.sh
+        INSTALLATION_SCRIPT_CHECKSUM: 41c0df6833bd371cbebf38767cf358c94a3fd1547056281e3ae9cade53fb39e2
       name: Configure Datadog Test Visibility
       command: <<include(scripts/autoinstrument.sh)>>


### PR DESCRIPTION
### What does this PR do?

Updates the version of Test Visibility installation script to 4.

### Motivation

Script v4 fixes a Gradle auto-instrumentation issue: https://github.com/DataDog/test-visibility-install-script/pull/11