### PR TITLE
[SDTEST-900] Add Ruby support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # <img height="25" src="logos/test_visibility_logo.png" /> Datadog Test Optimization CircleCI Orb
 
 [CircleCI orb](https://circleci.com/orbs/registry/orb/datadog/test-visibility-circleci-orb) that installs and configures [Datadog Test Optimization](https://docs.datadoghq.com/tests/).
-Supported languages are .NET, Java, Javascript, and Python.
+Supported languages are .NET, Java, Javascript, Python, and Ruby.
 
 ## About Datadog Test Optimization
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# <img height="25" src="logos/test_visibility_logo.png" />  Datadog Test Visibility CircleCI Orb
+# <img height="25" src="logos/test_visibility_logo.png" /> Datadog Test Optimization CircleCI Orb
 
-[CircleCI orb](https://circleci.com/orbs/registry/orb/datadog/test-visibility-circleci-orb) that installs and configures [Datadog Test Visibility](https://docs.datadoghq.com/tests/).
+[CircleCI orb](https://circleci.com/orbs/registry/orb/datadog/test-visibility-circleci-orb) that installs and configures [Datadog Test Optimization](https://docs.datadoghq.com/tests/).
 Supported languages are .NET, Java, Javascript, and Python.
 
-## About Datadog Test Visibility
+## About Datadog Test Optimization
 
 [Test Visibility](https://docs.datadoghq.com/tests/) provides a test-first view into your CI health by displaying important metrics and results from your tests.
 It can help you investigate and mitigate performance problems and test failures that are most relevant to your work, focusing on the code you are responsible for, rather than the pipelines which run your tests.
@@ -14,7 +14,7 @@ It can help you investigate and mitigate performance problems and test failures 
 
 2. Execute this command orb as part of your CircleCI job YAML before running the tests. Set the languages and [site](https://docs.datadoghq.com/getting_started/site/) parameters:
 
- ```yaml
+```yaml
 version: 2.1
 
 orbs:
@@ -31,22 +31,23 @@ jobs:
           languages: python
           site: datadoghq.com
       - run: pytest
- ```
+```
 
 ## Configuration
 
 The orb has the following parameters:
 
-| Name | Description | Required | Default |
-| ---- | ----------- | -------- | ------- |
- | languages | List of languages to be instrumented. Can be either "all" or any of "java", "js", "python", "dotnet" (multiple languages can be specified as a space-separated list). | true | |
- | site | Datadog site. See https://docs.datadoghq.com/getting_started/site for more information about sites. | false | datadoghq.com |
- | service | The name of the service or library being tested. | false | |
- | dotnet_tracer_version | The version of Datadog .NET tracer to use. Defaults to the latest release. | false | |
- | java_tracer_version | The version of Datadog Java tracer to use. Defaults to the latest release. | false | |
- | js_tracer_version | The version of Datadog JS tracer to use. Defaults to the latest release. | false | |
- | python_tracer_version | The version of Datadog Python tracer to use. Defaults to the latest release. | false | |
- | java_instrumented_build_system | If provided, only the specified build systems will be instrumented (allowed values are `gradle`,`maven`,`sbt`,`ant`,`all`). `all` is a special value that instruments every Java process. If this property is not provided, all known build systems will be instrumented (Gradle, Maven, SBT, Ant). | false | |
+| Name                           | Description                                                                                                                                                                                                                                                                                         | Required | Default       |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------- |
+| languages                      | List of languages to be instrumented. Can be either "all" or any of "java", "js", "python", "dotnet", "ruby" (multiple languages can be specified as a space-separated list).                                                                                                                       | true     |               |
+| site                           | Datadog site. See https://docs.datadoghq.com/getting_started/site for more information about sites.                                                                                                                                                                                                 | false    | datadoghq.com |
+| service                        | The name of the service or library being tested.                                                                                                                                                                                                                                                    | false    |               |
+| dotnet_tracer_version          | The version of Datadog .NET tracer to use. Defaults to the latest release.                                                                                                                                                                                                                          | false    |               |
+| java_tracer_version            | The version of Datadog Java tracer to use. Defaults to the latest release.                                                                                                                                                                                                                          | false    |               |
+| js_tracer_version              | The version of Datadog JS tracer to use. Defaults to the latest release.                                                                                                                                                                                                                            | false    |               |
+| python_tracer_version          | The version of Datadog Python tracer to use. Defaults to the latest release.                                                                                                                                                                                                                        | false    |               |
+| ruby_tracer_version            | The version of datadog-ci gem to use. Defaults to the latest release.                                                                                                                                                                                                                               | false    |               |
+| java_instrumented_build_system | If provided, only the specified build systems will be instrumented (allowed values are `gradle`,`maven`,`sbt`,`ant`,`all`). `all` is a special value that instruments every Java process. If this property is not provided, all known build systems will be instrumented (Gradle, Maven, SBT, Ant). | false    |               |
 
 ### Additional configuration
 
@@ -96,4 +97,4 @@ jobs:
 
 ### Tracing cypress tests
 
-To instrument your [Cypress](https://www.cypress.io/) tests with Datadog Test Visibility, please follow the manual steps in the [docs](https://docs.datadoghq.com/tests/setup/javascript/?tab=cypress).
+To instrument your [Cypress](https://www.cypress.io/) tests with Datadog Test Optimization, please follow the manual steps in the [docs](https://docs.datadoghq.com/tests/setup/javascript/?tab=cypress).

--- a/src/commands/autoinstrument.yml
+++ b/src/commands/autoinstrument.yml
@@ -28,6 +28,10 @@ parameters:
     description: 'The version of Datadog Python tracer to use (optional). Defaults to the latest release.'
     type: string
     default: ''
+  ruby_tracer_version:
+    description: 'The version of datadog-ci gem to use (optional). Defaults to the latest release.'
+    type: string
+    default: ''
   java_instrumented_build_system:
     description: 'If provided, only the specified build systems will be instrumented (allowed values are `gradle` and `maven`). Otherwise every Java process will be instrumented.'
     type: string
@@ -42,8 +46,9 @@ steps:
         DD_SET_TRACER_VERSION_JAVA: <<parameters.java_tracer_version>>
         DD_SET_TRACER_VERSION_JS: <<parameters.js_tracer_version>>
         DD_SET_TRACER_VERSION_PYTHON: <<parameters.python_tracer_version>>
+        DD_SET_TRACER_VERSION_RUBY: <<parameters.ruby_tracer_version>>
         DD_INSTRUMENTATION_BUILD_SYSTEM_JAVA: <<parameters.java_instrumented_build_system>>
-        INSTALLATION_SCRIPT_URL: https://install.datadoghq.com/scripts/install_test_visibility_v4.sh
-        INSTALLATION_SCRIPT_CHECKSUM: 41c0df6833bd371cbebf38767cf358c94a3fd1547056281e3ae9cade53fb39e2
+        INSTALLATION_SCRIPT_URL: https://install.datadoghq.com/scripts/install_test_visibility_v5.sh
+        INSTALLATION_SCRIPT_CHECKSUM: 903f1146fe123a1f7c6accdc48411546eead172f2d577fb41876d29b537eb7d6
       name: Configure Datadog Test Visibility
       command: <<include(scripts/autoinstrument.sh)>>


### PR DESCRIPTION
### What does this PR do?

Migrates this orb to use script install_test_visibility_v5.sh which supports Ruby.

### Motivation

Ruby support is released

### Describe how to test/QA your changes

Smoke test is done with circleci job, will perform end2end test with Ruby project after release