### PR TITLE
[SDTEST-1754] upgrade script to v10 and print Ruby library version after auto instrumentation step

### DIFF
--- a/src/commands/autoinstrument.yml
+++ b/src/commands/autoinstrument.yml
@@ -53,7 +53,7 @@ steps:
         DD_SET_TRACER_VERSION_RUBY: <<parameters.ruby_tracer_version>>
         DD_SET_TRACER_VERSION_GO: <<parameters.go_tracer_version>>
         DD_INSTRUMENTATION_BUILD_SYSTEM_JAVA: <<parameters.java_instrumented_build_system>>
-        INSTALLATION_SCRIPT_URL: https://install.datadoghq.com/scripts/install_test_visibility_v9.sh
-        INSTALLATION_SCRIPT_CHECKSUM: dc524d824779b96fee12f6bf28b12f7da5c7095499bb82bc07981bdb60d6623a
+        INSTALLATION_SCRIPT_URL: https://install.datadoghq.com/scripts/install_test_visibility_v10.sh
+        INSTALLATION_SCRIPT_CHECKSUM: 6fac0cc8224499a155e7253b936520ae763dce7bfec04900220f1a5a885821fc
       name: Configure Datadog Test Visibility
       command: <<include(scripts/autoinstrument.sh)>>

--- a/src/scripts/autoinstrument.sh
+++ b/src/scripts/autoinstrument.sh
@@ -72,4 +72,7 @@ fi
 if [ -n "$DD_TRACER_VERSION_GO" ]; then
   echo "- __Go:__ $DD_TRACER_VERSION_GO"
 fi
+if [ -n "$DD_TRACER_VERSION_RUBY" ]; then
+  echo "- __Ruby:__ $DD_TRACER_VERSION_RUBY"
+fi
 echo "---"


### PR DESCRIPTION
### What does this PR do?

Fixes an issue with Ruby library version not being printed after auto instrumentation step by upgrading to v10 of installation script and using the DD_TRACER_VERSION_RUBY env variable after auto instrumentation

### Motivation

Fix for https://github.com/DataDog/test-visibility-install-script/issues/18

